### PR TITLE
同じ食品名が複数選択された場合、数値が0にならないように修正。

### DIFF
--- a/purineChecker/src/main/java/model/Calculate.java
+++ b/purineChecker/src/main/java/model/Calculate.java
@@ -16,10 +16,6 @@ public class Calculate {
 		//FoodDaoに100gあたりのプリン体含有量の取得を依頼
 		FoodDao dao = new FoodDao();
 		List<Food> foods = dao.findFood(getFoods);
-		System.out.println(foods.get(0).getName().strip() == foods.get(1).getName().strip());
-		System.out.println(foods.get(0).getName().trim());
-		System.out.println(foods.get(1).getName().trim());
-		
 		
 		for(Food food : foods) {
 			//100gあたりのプリン体含有量が0になっているときは


### PR DESCRIPTION
データベースから100gあたりのプリン体含有量を取得時に、2個目以降の同名食品の数値が0になる問題を修正しました。(
取得済みの1個目の食品の数値を代入)